### PR TITLE
Removing measuring section in Electricity.md

### DIFF
--- a/Principles/Electricity.md
+++ b/Principles/Electricity.md
@@ -41,10 +41,6 @@ Most electricity is still produced by burning fossil fuels and is responsible fo
 * Green energy = sources from nature
 * Renewable energy = recyclable sources
 
-## Measuring energy consumption 
-
-A simple yet effective way to measure the energy consumption of an application is directly from the wall socket using a watt*hour meter. The meter measures how much electrical energy is used over time. While this measurement is for the whole device, it is easily adaptable for a single application running on the device. We can ensure that only the concerned application is running, so we can substrate the application's consumption from the total consumption of the device. As for mobile applications, there are readily available energy profilers for Android and iOS applications built into their respective development tool kits.
-
 ## Power usage effectiveness
 
 The data centre industry uses power usage effectiveness (PUE), developed by Green Grid in 2006, to measure data centre energy efficiency, specifically, how much energy the computing equipment uses in contrast to cooling and other overhead supporting the equipment. Computing gets to use nearly all energy when a data centre's PUE is close to 1.0. When PUE is 2.0, an additional watt of IT power is required to cool and distribute power to the IT equipment for every watt of IT power. 
@@ -67,7 +63,7 @@ This is the static power draw of a computer. The static power draw varies by con
 Servers are usually not configured for aggressive or even minimal power-saving. Many use-cases running on servers demand total capacity as quickly as possible because the server needs to respond to rapidly changing demands, which lead to many servers in idle modes during low demand periods. An idle server costs carbon from the embedded carbon and its inefficient utilisation.
 
 ## Summary
-Green software engineers take responsibility for their application's electricity consumption and carbon emissions. We should always choose clean energy to power our applications. If clean energy is not available, we can instead strive for hardware efficiency. Use as few servers as possible and ensure that the servers are running at the highest utilisation rate. There are many tools available to measure an application's energy consumption. Calculating or estimating the energy consumption of an application is a step in the correct direction to start thinking about how an application can operate more efficiently.  
+Green software proffessional take responsibility for their application's electricity consumption and carbon emissions. We should always choose clean energy to power our applications. If clean energy is not available, we can instead strive for hardware efficiency. Use as few servers as possible and ensure that the servers are running at the highest utilisation rate. There are many tools available to measure an application's energy consumption. Calculating or estimating the energy consumption of an application is a step in the correct direction to start thinking about how an application can operate more efficiently.  
 
 Reference
 * https://principles.green/principles/electricity/


### PR DESCRIPTION
Once the patterns database is up and we have a section on measuring energy I think it would be best to point people to that from the principles than describe just two methods here. The suggestions here are accurate but also incomplete, there are many dozens of ways of measuring (i.e. Intel RAPL, Scaphandre, Windows E3 are just 3 but there are loads more including models which we are coming up with. I think it's better to list them all in the patterns database and point this doc to that once it's ready.